### PR TITLE
Populating first class service_name

### DIFF
--- a/raw-span-constants/build.gradle.kts
+++ b/raw-span-constants/build.gradle.kts
@@ -43,6 +43,14 @@ protobuf {
   }
 }
 
+sourceSets {
+  main {
+    java {
+      srcDirs("src/main/java", "build/generated/source/proto/main/java", "build/generated/source/proto/main/grpc_java")
+    }
+  }
+}
+
 dependencies {
   api("com.google.protobuf:protobuf-java-util:3.7.0")
   implementation("org.slf4j:slf4j-api:1.7.30")

--- a/span-normalizer-api/build.gradle.kts
+++ b/span-normalizer-api/build.gradle.kts
@@ -42,7 +42,13 @@ protobuf {
     }
   }
 }
-
+sourceSets {
+  main {
+    java {
+      srcDirs("src/main/java", "build/generated/source/proto/main/java", "build/generated/source/proto/main/grpc_java")
+    }
+  }
+}
 dependencies {
   api("com.google.api.grpc:proto-google-common-protos:1.12.0")
 }

--- a/span-normalizer/build.gradle.kts
+++ b/span-normalizer/build.gradle.kts
@@ -47,5 +47,4 @@ dependencies {
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
-  testImplementation("org.mockito:mockito-core:2.19.0")
 }

--- a/span-normalizer/build.gradle.kts
+++ b/span-normalizer/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   implementation(project(":raw-span-constants"))
   implementation(project(":span-normalizer-api"))
 
-  implementation("org.hypertrace.core.datamodel:data-model:0.1.0")
+  implementation("org.hypertrace.core.datamodel:data-model:0.1.1")
   implementation("org.hypertrace.core.flinkutils:flink-utils:0.1.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.2")
 

--- a/span-normalizer/build.gradle.kts
+++ b/span-normalizer/build.gradle.kts
@@ -47,4 +47,5 @@ dependencies {
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  testImplementation("org.mockito:mockito-core:2.19.0")
 }

--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -234,7 +234,7 @@ public class JaegerSpanNormalizer implements SpanNormalizer<Span, RawSpan> {
       attributeFieldMap.put(
           RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),
           AttributeValueCreator.create(jaegerSpan.getProcess().getServiceName()));
-      jaegerFieldsBuilder.setServiceName(jaegerSpan.getProcess().getServiceName());
+      eventBuilder.setServiceName(jaegerSpan.getProcess().getServiceName());
     }
 
     // EVENT METRICS

--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -238,6 +238,7 @@ public class JaegerSpanNormalizer implements SpanNormalizer<Span, RawSpan> {
     }
 
     // EVENT METRICS
+
     Map<String, MetricValue> metricMap = new HashMap<>();
     MetricValue durationMetric =
         MetricValue.newBuilder().setValue((double) (endTimeMillis - startTimeMillis)).build();

--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -229,7 +229,8 @@ public class JaegerSpanNormalizer implements SpanNormalizer<Span, RawSpan> {
     }
 
     // Jaeger service name
-    if (jaegerSpan.getProcess() != null && jaegerSpan.getProcess().getServiceName() != null) {
+    if (jaegerSpan.getProcess() != null && jaegerSpan.getProcess().getServiceName() != null
+        && !jaegerSpan.getProcess().getServiceName().isEmpty()) {
       // Keep the attribute for now due to backwards compatibility
       attributeFieldMap.put(
           RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),

--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/jaeger/JaegerSpanNormalizer.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Attributes;
 import org.hypertrace.core.datamodel.Event;
@@ -229,8 +230,8 @@ public class JaegerSpanNormalizer implements SpanNormalizer<Span, RawSpan> {
     }
 
     // Jaeger service name
-    if (jaegerSpan.getProcess() != null && jaegerSpan.getProcess().getServiceName() != null
-        && !jaegerSpan.getProcess().getServiceName().isEmpty()) {
+    if (jaegerSpan.getProcess() != null
+        && !StringUtils.isEmpty(jaegerSpan.getProcess().getServiceName())) {
       // Keep the attribute for now due to backwards compatibility
       attributeFieldMap.put(
           RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME),

--- a/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/JaegerSpanNormalizerTest.java
@@ -138,4 +138,21 @@ public class JaegerSpanNormalizerTest {
     Assertions.assertEquals("testService", rawSpan.getEvent().getAttributes().getAttributeMap().get(
         RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME)).getValue());
   }
+
+  @Test
+  public void testServiceNameNotAddededToEvent() {
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "defaultTenantId", "tenant-1")));
+    JaegerSpanNormalizer normalizer = JaegerSpanNormalizer.get(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().build();
+    Span span = Span.newBuilder().setProcess(process).build();
+    RawSpan rawSpan = normalizer.convert(span);
+    Assertions.assertNull(rawSpan.getEvent().getServiceName());
+    Assertions.assertNull(rawSpan.getEvent().getAttributes().getAttributeMap().get(
+        RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME)));
+  }
 }

--- a/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/JaegerSpanNormalizerTest.java
+++ b/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/JaegerSpanNormalizerTest.java
@@ -2,10 +2,15 @@ package org.hypertrace.core.spannormalizer;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel.Process;
+import io.jaegertracing.api_v2.JaegerSpanInternalModel.Span;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import org.hypertrace.core.datamodel.RawSpan;
+import org.hypertrace.core.span.constants.RawSpanConstants;
+import org.hypertrace.core.span.constants.v1.JaegerAttribute;
 import org.hypertrace.core.spannormalizer.jaeger.JaegerSpanNormalizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,5 +120,22 @@ public class JaegerSpanNormalizerTest {
               .contains(
                   "Both processor.tenantIdTagKey and processor.defaultTenantId configs shouldn't exist at same time"));
     }
+  }
+
+  @Test
+  public void testServiceNameAddededToEvent() {
+    Map<String, Object> configs = new HashMap<>(getCommonConfig());
+    configs.putAll(
+        Map.of(
+            "processor",
+            Map.of(
+                "defaultTenantId", "tenant-1")));
+    JaegerSpanNormalizer normalizer = JaegerSpanNormalizer.get(ConfigFactory.parseMap(configs));
+    Process process = Process.newBuilder().setServiceName("testService").build();
+    Span span = Span.newBuilder().setProcess(process).build();
+    RawSpan rawSpan = normalizer.convert(span);
+    Assertions.assertEquals("testService", rawSpan.getEvent().getServiceName());
+    Assertions.assertEquals("testService", rawSpan.getEvent().getAttributes().getAttributeMap().get(
+        RawSpanConstants.getValue(JaegerAttribute.JAEGER_ATTRIBUTE_SERVICE_NAME)).getValue());
   }
 }


### PR DESCRIPTION
Not removing ```JAEGER_ATTRIBUTE_SERVICE_NAME``` to maintain backward compatibility