### PR TITLE
Don't explicitly set a flink kafka partitioner

### DIFF
--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/SpanNormalizerJob.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/SpanNormalizerJob.java
@@ -89,7 +89,9 @@ public class SpanNormalizerJob implements PlatformBackgroundJob {
         new RegistryBasedAvroSerde<>(outputTopic, RawSpan.class, sinkSchemaRegistryConfig);
     outputStream.addSink(
         FlinkUtils.getFlinkKafkaProducer(
-            outputTopic, serializationSchema, kafkaProducerConfig, logFailuresOnly));
+            outputTopic, serializationSchema,
+            null/* By specifying null this will default to kafka producer's default partitioner i.e. round-robin*/,
+            kafkaProducerConfig, logFailuresOnly));
     environment.execute(SpanNormalizerJob.class.getSimpleName());
   }
 


### PR DESCRIPTION
Currently the FlinkFixedPartitioner uses a static mapping i.e. subtask_id % num_partitions and the subtask_id is dependent on the *parallelism* config specified.

This has 2 problems:

1. The parallelism is specified for the producer (upstream job) and can be different from the downstream job.
2. The number of partitions could be different across the upstream and downstream jobs

To avoid skew by not explicitly specifying a partitioner flink will fallback on Kafka producer's default partitioning strategy - which is round-robin.