### PR TITLE
Moves to new docker plugin which corrects port defaults and health check

### DIFF
--- a/span-normalizer/build.gradle.kts
+++ b/span-normalizer/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
   java
   application
   jacoco
-  id("org.hypertrace.docker-java-application-plugin") version "0.4.0"
-  id("org.hypertrace.docker-publish-plugin") version "0.4.0"
+  id("org.hypertrace.docker-java-application-plugin") version "0.5.1"
+  id("org.hypertrace.docker-publish-plugin") version "0.5.1"
   id("org.hypertrace.jacoco-report-plugin")
 }
 
@@ -16,9 +16,18 @@ application {
   mainClassName = "org.hypertrace.core.serviceframework.PlatformServiceLauncher"
 }
 
+hypertraceDocker {
+  defaultImage {
+    javaApplication {
+      serviceName.set("${project.name}")
+      adminPort.set(8099)
+    }
+  }
+}
+
 // Config for gw run to be able to run this locally. Just execute gw run here on Intellij or on the console.
 tasks.run<JavaExec> {
-  jvmArgs = listOf("-Dbootstrap.config.uri=file:${projectDir}/src/main/resources/configs", "-Dservice.name=span-normalizer")
+  jvmArgs = listOf("-Dbootstrap.config.uri=file:${projectDir}/src/main/resources/configs", "-Dservice.name=${project.name}")
 }
 
 tasks.test {


### PR DESCRIPTION
After
```
span-normalizer                java -cp /app/resources:/a ...   Up (healthy)   8099/tcp
```