### PR TITLE
replace jaeger.servicename with servicename

### DIFF
--- a/raw-span-constants/src/main/proto/org/hypertrace/core/span/constants/v1/span_attribute.proto
+++ b/raw-span-constants/src/main/proto/org/hypertrace/core/span/constants/v1/span_attribute.proto
@@ -174,5 +174,5 @@ enum TracerAttribute {
 
 enum JaegerAttribute {
     JAEGER_ATTRIBUTE_UNSPECIFIED = 0 [(string_value) = "unspecified"];
-    JAEGER_ATTRIBUTE_SERVICE_NAME = 1 [(string_value) = "jaeger.servicename"];
+    JAEGER_ATTRIBUTE_SERVICE_NAME = 1 [(string_value) = "servicename"];
 }


### PR DESCRIPTION
Even jaeger would not qualify servicename as jaeger.servicename. So it is more sensible for HT to rename it to serviceName as idiomatically used in the rest of HT.