### PR TITLE
Add prometheus jmx exporter for exporting kafka-streams metrics

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -25,8 +25,10 @@ spec:
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/span-normalizer-config.yaml") . | sha256sum }}
+        {{- if .Values.prometheus.jmx.enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.containerAdminPort }}"
+        prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,6 +44,11 @@ spec:
         - name: log4j-config
           configMap:
             name: {{ .Values.logConfig.name }}
+        {{- if .Values.prometheus.jmx.enabled }}
+        - name: jmx-config
+          configMap:
+            name: {{ .Chart.Name }}-jmx-config
+        {{- end }}
     {{- with .Values.nodeLabels }}
       nodeSelector:
       {{- toYaml . | nindent 8}}
@@ -62,7 +69,7 @@ spec:
             - name: LOG4J_CONFIGURATION_FILE
               value: "/var/{{ .Chart.Name }}/log/log4j2.properties"
             - name: JAVA_TOOL_OPTIONS
-              value: {{ .Values.javaOpts | quote }}
+              value: {{ .Values.javaOpts }} {{ if .Values.jmx.enabled }}{{ .Values.jmx.opts }}{{ end }}
           volumeMounts:
             - name: service-config
               mountPath: /app/resources/configs/{{ .Chart.Name }}/application.conf
@@ -82,3 +89,26 @@ spec:
               port: {{ .Values.containerAdminPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.prometheus.jmx.enabled }}
+        - name: prometheus-jmx-exporter
+          image: "{{ .Values.prometheus.jmx.image.repository }}:{{ .Values.prometheus.jmx.image.tag }}"
+          imagePullPolicy: "{{ .Values.prometheus.jmx.image.pullPolicy }}"
+          command:
+            - java
+            - -XX:+UnlockExperimentalVMOptions
+            - -XX:+UseCGroupMemoryLimitForHeap
+            - -XX:MaxRAMFraction=1
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - {{ .Values.prometheus.jmx.port | quote }}
+            - /etc/jmx-config/prometheus-span-normalizer.yaml
+          ports:
+            - name: prometheus-jmx
+              containerPort: {{ .Values.prometheus.jmx.port }}
+          resources:
+            {{- toYaml .Values.prometheus.jmx.resources | nindent 12 }}
+          volumeMounts:
+            - name: jmx-config
+              mountPath: /etc/jmx-config
+        {{- end }}

--- a/helm/templates/jmx-configmap.yaml
+++ b/helm/templates/jmx-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-jmx-config
+  labels:
+    release: {{ .Release.Name }}
+  {{- with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  prometheus-span-normalizer.yaml: |-
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:{{ .Values.jmx.port }}/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    release: {{ .Release.Name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.containerAdminPort | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.containerAdminPort }}
+      targetPort: admin-port
+      protocol: TCP
+      name: admin-port
+  selector:
+    {{- toYaml .Values.serviceSelectorLabels | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -65,6 +65,9 @@ podAnnotations: {}
 deploymentSelectorMatchLabels:
   app: span-normalizer
 
+serviceSelectorLabels:
+  app: span-normalizer
+
 ###########
 # Config Maps
 ###########
@@ -86,6 +89,23 @@ logConfig:
   appender:
     rolling:
       enabled: false
+
+jmx:
+  enabled: true
+  port: 7022
+  opts: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.port=7022 -Dcom.sun.management.jmxremote.rmi.port=7022 -Djava.rmi.server.hostname=127.0.0.1"
+prometheus:
+  jmx:
+    enabled: true
+    port: 7071
+    image:
+      repository: solsson/kafka-prometheus-jmx-exporter@sha256
+      tag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: "0.25"
+        memory: "256Mi"
 
 kafka-topic-creator:
   enabled: true


### PR DESCRIPTION
Added a sidecar container for exposing kafka-streams metrics to prometheus to scrape.

Prometheus now has to scrape two endpoints - admin port and prometheus jmx exporter port. one of them will be configured through pod annotations and second will be configured using service annotations.  hence, a new service is also added to the helm chart.