### PR TITLE
Publish span-normalizer-constants

### DIFF
--- a/span-normalizer-constants/build.gradle.kts
+++ b/span-normalizer-constants/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   `java-library`
   jacoco
   id("org.hypertrace.jacoco-report-plugin")
+  id("org.hypertrace.publish-plugin")
 }
 
 dependencies {


### PR DESCRIPTION
We should use span normalizer constants where ever needed.