### PR TITLE
Fixes hypertrace/hypertrace-ui#283 - Handle relative URLs to extract out path and query string

### DIFF
--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -483,6 +483,8 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
 
     String urlStr = requestBuilder.getUrl();
     try {
+      // constructing a URI object here instead of a URL object so that it can handle the cases where url field
+      // contains only path name (like "/customer?customer=392")
       URI uri = new URI(urlStr);
       requestBuilder.setScheme(uri.getScheme());
       requestBuilder.setHost(

--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -516,7 +516,7 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
     }
   }
 
-  private boolean isAbsoluteUrl(String url) {
+  private static boolean isAbsoluteUrl(String url) {
     try {
       new URL(url);
       return true;

--- a/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
+++ b/span-normalizer/src/main/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGenerator.java
@@ -38,8 +38,6 @@ import static org.hypertrace.core.span.constants.v1.OTSpanTag.OT_SPAN_TAG_HTTP_U
 
 import io.jaegertracing.api_v2.JaegerSpanInternalModel;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -418,7 +416,7 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
       return;
     }
 
-    getPathFromUriObject(pathFromAttrs.get())
+    getPathFromUrlObject(pathFromAttrs.get())
         .map(HttpFieldsGenerator::removeTrailingSlash)
         .ifPresent(path -> httpBuilder.getRequestBuilder().setPath(path));
   }
@@ -428,11 +426,11 @@ public class HttpFieldsGenerator extends ProtocolFieldsGenerator<Http.Builder> {
     return s.endsWith(SLASH) && s.length() > 1 ? s.substring(0, s.length() - 1) : s;
   }
 
-  private static Optional<String> getPathFromUriObject(String urlPath) {
+  private static Optional<String> getPathFromUrlObject(String urlPath) {
     try {
-      URI uri = new URI(urlPath);
-      return Optional.of(uri.getPath());
-    } catch (URISyntaxException e) {
+      URL url = new URL(dummyUrl, urlPath);
+      return Optional.of(url.getPath());
+    } catch (MalformedURLException e) {
       return Optional.empty();
     }
   }

--- a/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java
+++ b/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java
@@ -567,32 +567,20 @@ public class HttpFieldsGeneratorTest {
   }
 
   @Test
-  public void testInvalidUrl() {
+  public void testIncompleteUrl() {
     HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
 
-    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap1 = new HashMap<>();
-    tagsMap1.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("/dispatch/test?a=b&k1=v1"));
+    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
+    tagsMap.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("/dispatch/test?a=b&k1=v1"));
 
-    Event.Builder eventBuilder1 = Event.newBuilder();
-    Http.Builder httpBuilder1 = httpFieldsGenerator.getProtocolBuilder(eventBuilder1);
+    Event.Builder eventBuilder = Event.newBuilder();
+    Http.Builder httpBuilder = httpFieldsGenerator.getProtocolBuilder(eventBuilder);
 
-    tagsMap1.forEach(
+    tagsMap.forEach(
         (key, keyValue) ->
-            httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder1, tagsMap1));
+            httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder, tagsMap));
 
-    Assertions.assertNull(httpBuilder1.getRequestBuilder().getUrl());
-
-    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap2 = new HashMap<>();
-    tagsMap2.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("http://abc.xyz/dispatch/test?a=b&k1=v1"));
-
-    Event.Builder eventBuilder2 = Event.newBuilder();
-    Http.Builder httpBuilder2 = httpFieldsGenerator.getProtocolBuilder(eventBuilder2);
-
-    tagsMap2.forEach(
-            (key, keyValue) ->
-                    httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder2, tagsMap2));
-
-    Assertions.assertEquals("http://abc.xyz/dispatch/test?a=b&k1=v1", httpBuilder2.getRequestBuilder().getUrl());
+    Assertions.assertEquals("/dispatch/test?a=b&k1=v1", httpBuilder.getRequestBuilder().getUrl());
   }
 
   @Test
@@ -673,6 +661,16 @@ public class HttpFieldsGeneratorTest {
     Assertions.assertEquals("/", eventBuilder.getHttpBuilder().getRequestBuilder().getPath());
     Assertions.assertEquals(
         "a1=v1&a2=v2", eventBuilder.getHttpBuilder().getRequestBuilder().getQueryString());
+
+    // No scheme and host name
+    eventBuilder = Event.newBuilder();
+    eventBuilder.getHttpBuilder().getRequestBuilder().setUrl("/apis/5673/events?a1=v1&a2=v2");
+    httpFieldsGenerator.populateOtherFields(eventBuilder);
+
+    Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getScheme());
+    Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getHost());
+    Assertions.assertEquals("/apis/5673/events", eventBuilder.getHttpBuilder().getRequestBuilder().getPath());
+    Assertions.assertEquals("a1=v1&a2=v2", eventBuilder.getHttpBuilder().getRequestBuilder().getQueryString());
 
     // Set path and query string before calling populateOtherFields. Simulate case where fields came
     // from attributes

--- a/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java
+++ b/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java
@@ -567,32 +567,54 @@ public class HttpFieldsGeneratorTest {
   }
 
   @Test
-  public void testInvalidUrl() {
+  public void testRelativeUrl() {
     HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
 
-    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap1 = new HashMap<>();
-    tagsMap1.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("/dispatch/test?a=b&k1=v1"));
+    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
+    tagsMap.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("/dispatch/test?a=b&k1=v1"));
 
-    Event.Builder eventBuilder1 = Event.newBuilder();
-    Http.Builder httpBuilder1 = httpFieldsGenerator.getProtocolBuilder(eventBuilder1);
+    Event.Builder eventBuilder = Event.newBuilder();
+    Http.Builder httpBuilder = httpFieldsGenerator.getProtocolBuilder(eventBuilder);
 
-    tagsMap1.forEach(
-        (key, keyValue) ->
-            httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder1, tagsMap1));
-
-    Assertions.assertNull(httpBuilder1.getRequestBuilder().getUrl());
-
-    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap2 = new HashMap<>();
-    tagsMap2.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("http://abc.xyz/dispatch/test?a=b&k1=v1"));
-
-    Event.Builder eventBuilder2 = Event.newBuilder();
-    Http.Builder httpBuilder2 = httpFieldsGenerator.getProtocolBuilder(eventBuilder2);
-
-    tagsMap2.forEach(
+    tagsMap.forEach(
             (key, keyValue) ->
-                    httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder2, tagsMap2));
+                    httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder, tagsMap));
+    Assertions.assertEquals("/dispatch/test?a=b&k1=v1", httpBuilder.getRequestBuilder().getUrl());
 
-    Assertions.assertEquals("http://abc.xyz/dispatch/test?a=b&k1=v1", httpBuilder2.getRequestBuilder().getUrl());
+    httpFieldsGenerator.populateOtherFields(eventBuilder);
+    Assertions.assertNull(httpBuilder.getRequestBuilder().getUrl());
+  }
+
+  @Test
+  public void testAbsoluteUrl() {
+    HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
+    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
+    tagsMap.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("http://abc.xyz/dispatch/test?a=b&k1=v1"));
+
+    Event.Builder eventBuilder = Event.newBuilder();
+    Http.Builder httpBuilder = httpFieldsGenerator.getProtocolBuilder(eventBuilder);
+
+    tagsMap.forEach(
+            (key, keyValue) ->
+                    httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder, tagsMap));
+    httpFieldsGenerator.populateOtherFields(eventBuilder);
+
+    Assertions.assertEquals("http://abc.xyz/dispatch/test?a=b&k1=v1", httpBuilder.getRequestBuilder().getUrl());
+  }
+
+  @Test
+  public void testInvalidUrl() {
+    HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
+    Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
+    tagsMap.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("xyz://abc.xyz/dispatch/test?a=b&k1=v1"));
+
+    Event.Builder eventBuilder = Event.newBuilder();
+    Http.Builder httpBuilder = httpFieldsGenerator.getProtocolBuilder(eventBuilder);
+
+    tagsMap.forEach(
+            (key, keyValue) ->
+                    httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder, tagsMap));
+    Assertions.assertNull(httpBuilder.getRequestBuilder().getUrl());
   }
 
   @Test
@@ -661,6 +683,17 @@ public class HttpFieldsGeneratorTest {
         "example.ai", eventBuilder.getHttpBuilder().getRequestBuilder().getHost());
     Assertions.assertEquals("/", eventBuilder.getHttpBuilder().getRequestBuilder().getPath());
     Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getQueryString());
+
+    // Relative URL
+    eventBuilder = Event.newBuilder();
+    eventBuilder.getHttpBuilder().getRequestBuilder().setUrl("/apis/5673/events?a1=v1&a2=v2");
+    httpFieldsGenerator.populateOtherFields(eventBuilder);
+
+    Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getUrl());
+    Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getScheme());
+    Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getHost());
+    Assertions.assertEquals("/apis/5673/events", eventBuilder.getHttpBuilder().getRequestBuilder().getPath());
+    Assertions.assertEquals("a1=v1&a2=v2", eventBuilder.getHttpBuilder().getRequestBuilder().getQueryString());
 
     // "/" home path, host with port
     eventBuilder = Event.newBuilder();

--- a/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java
+++ b/span-normalizer/src/test/java/org/hypertrace/core/spannormalizer/fieldgenerators/HttpFieldsGeneratorTest.java
@@ -567,7 +567,7 @@ public class HttpFieldsGeneratorTest {
   }
 
   @Test
-  public void testRelativeUrl() {
+  public void testRelativeUrlNotSetsUrlField() {
     HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
 
     Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
@@ -581,12 +581,12 @@ public class HttpFieldsGeneratorTest {
                     httpFieldsGenerator.addValueToBuilder(key, keyValue, eventBuilder, tagsMap));
     Assertions.assertEquals("/dispatch/test?a=b&k1=v1", httpBuilder.getRequestBuilder().getUrl());
 
-    httpFieldsGenerator.populateOtherFields(eventBuilder);
+    httpFieldsGenerator.populateOtherFields(eventBuilder);  // this should unset the url field
     Assertions.assertNull(httpBuilder.getRequestBuilder().getUrl());
   }
 
   @Test
-  public void testAbsoluteUrl() {
+  public void testAbsoluteUrlSetsUrlField() {
     HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
     Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
     tagsMap.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("http://abc.xyz/dispatch/test?a=b&k1=v1"));
@@ -603,7 +603,7 @@ public class HttpFieldsGeneratorTest {
   }
 
   @Test
-  public void testInvalidUrl() {
+  public void testInvalidUrlRejectedByUrlValidator() {
     HttpFieldsGenerator httpFieldsGenerator = new HttpFieldsGenerator();
     Map<String, JaegerSpanInternalModel.KeyValue> tagsMap = new HashMap<>();
     tagsMap.put(RawSpanConstants.getValue(HTTP_URL), createKeyValue("xyz://abc.xyz/dispatch/test?a=b&k1=v1"));
@@ -684,7 +684,7 @@ public class HttpFieldsGeneratorTest {
     Assertions.assertEquals("/", eventBuilder.getHttpBuilder().getRequestBuilder().getPath());
     Assertions.assertNull(eventBuilder.getHttpBuilder().getRequestBuilder().getQueryString());
 
-    // Relative URL
+    // Relative URL - should extract path and query string only
     eventBuilder = Event.newBuilder();
     eventBuilder.getHttpBuilder().getRequestBuilder().setUrl("/apis/5673/events?a1=v1&a2=v2");
     httpFieldsGenerator.populateOtherFields(eventBuilder);


### PR DESCRIPTION
Sometimes, the HTTP URL tags may not contain the full URL - they may only contain a relative URL(or the path). E.g. "/customer?customer=392". In such cases, even though we set the Url field to null, we should be able to extract out the path and the query string, which is what these changes aim to achieve.