### PR TITLE
disable publish and package charts workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,25 +163,25 @@ workflows:
             branches:
               ignore:
                 - main
-      - publish:
-          context:
-            - hypertrace-publishing
-            - dockerhub-read
-          requires:
-            - build
-            - validate-charts
-            - snyk-scan
-          filters:
-            branches:
-              only:
-                - main
-      - package-charts:
-          context:
-            - hypertrace-publishing
-            - dockerhub-read
-          requires:
-            - publish
-          filters:
-            branches:
-              only:
-                - main
+#      - publish:
+#          context:
+#            - hypertrace-publishing
+#            - dockerhub-read
+#          requires:
+#            - build
+#            - validate-charts
+#            - snyk-scan
+#          filters:
+#            branches:
+#              only:
+#                - main
+#      - package-charts:
+#          context:
+#            - hypertrace-publishing
+#            - dockerhub-read
+#          requires:
+#            - publish
+#          filters:
+#            branches:
+#              only:
+#                - main


### PR DESCRIPTION
As part of merging all submodules of hypetrace-ingester, we will disable publishing from the individual repo. Just an example PR while we actually plan out merging the below two PRs after final work
- https://github.com/hypertrace/hypertrace-ingester/pull/14
- https://github.com/hypertrace/hypertrace-ingester/pull/15
issue: https://github.com/hypertrace/hypertrace-ingester/issues/8